### PR TITLE
Can Bridge Node Documentation + CAN Send / Receive Nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ROS/CMakeLists.txt
 .venv
+.vscode

--- a/Examples/ROS/README.md
+++ b/Examples/ROS/README.md
@@ -310,3 +310,14 @@ int64 B
 # Response
 int64 Sum
 ```
+
+## rosdep
+To check where packages can be found: 
+```
+rosdep resolve --rosdistro=noetic ros_canopen
+```
+
+Install dependencies of all packages in {folder} that are not installed:
+```
+rosdep install --from-paths {folder} --ignore-src -r -y
+```

--- a/Examples/ROS/ros-can.md
+++ b/Examples/ROS/ros-can.md
@@ -1,0 +1,36 @@
+# ROS-CAN 
+
+## socketcan_bridge_node
+Spin up the node: 
+```
+rosrun socketcan_bridge socketcan_bridge_node _can_device:=vcan0
+```
+
+Interact with device parameter
+```
+rosparam set /socketcan_bridge_node/can_device "device"
+rosparam get /socketcan_bridge_node/can_device
+```
+
+This will publish all CAN messages received on the specified CAN device to
+the topic `/received_messages`. The messages are of type `can_msgs/Frame`
+and are stuctured as follows:
+```
+header: 
+  seq: 560
+  stamp: 
+    secs: 1653066255
+    nsecs: 550524554
+  frame_id: ''
+id: 5
+is_rtr: False
+is_extended: False
+is_error: False
+dlc: 3
+data: [5, 6, 7, 78, 28, 37, 16, 82]
+```
+
+To view the messages as they are published:
+```
+rostopic echo /received_messages
+```

--- a/Launch/paradigm.launch
+++ b/Launch/paradigm.launch
@@ -1,6 +1,11 @@
 <launch>
         <arg name="can_device" default="vcan0"/>
-        <node pkg="socketcan_bridge" type="socketcan_bridge_node" name="can_bridge" ns="para">
+ 
+        <node pkg="socketcan_bridge" type="socketcan_bridge_node" name="can_bridge" ns="para" output="screen">
                 <param name="can_device" value="$(arg can_device)"/>
         </node>
+
+        <node pkg="example_pkg" type="can_logger.py" name="can_logger" ns="para" output="screen">
+        </node>
+
 </launch>

--- a/Launch/paradigm.launch
+++ b/Launch/paradigm.launch
@@ -1,0 +1,6 @@
+<launch>
+        <arg name="can_device" default="vcan0"/>
+        <node pkg="socketcan_bridge" type="socketcan_bridge_node" name="can_bridge" ns="para">
+                <param name="can_device" value="$(arg can_device)"/>
+        </node>
+</launch>

--- a/Launch/paradigm.launch
+++ b/Launch/paradigm.launch
@@ -8,4 +8,7 @@
         <node pkg="example_pkg" type="can_logger.py" name="can_logger" ns="para" output="screen">
         </node>
 
+        <node pkg="example_pkg" type="can_sender.py" name="can_sender" ns="para" output="screen">
+        </node>
+
 </launch>

--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ pmake
 ```
 
 **Note: I have not seen this approach used before. There may be some pitfalls associated
-with this that we will absolutely swan dive into. Contingency: track the catkin workspace.** 
+with this that we will absolutely swan dive into. Contingency: track the catkin workspace.**

--- a/ROS/example_pkg/CMakeLists.txt
+++ b/ROS/example_pkg/CMakeLists.txt
@@ -161,6 +161,7 @@ include_directories(
 ## in contrast to setup.py, you can choose the destination
 catkin_install_python(PROGRAMS
   scripts/talker.py
+  scripts/can_logger.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/ROS/example_pkg/CMakeLists.txt
+++ b/ROS/example_pkg/CMakeLists.txt
@@ -162,6 +162,7 @@ include_directories(
 catkin_install_python(PROGRAMS
   scripts/talker.py
   scripts/can_logger.py
+  scripts/can_sender.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/ROS/example_pkg/package.xml
+++ b/ROS/example_pkg/package.xml
@@ -49,16 +49,21 @@
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+  
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>ros_canopen</build_depend>
+
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>ros_canopen</build_export_depend>
+
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-
+  <exec_depend>ros_canopen</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/ROS/example_pkg/scripts/can_logger.py
+++ b/ROS/example_pkg/scripts/can_logger.py
@@ -20,7 +20,7 @@ def handle_frame(frame: Frame):
     data = []
     for i in range(frame.dlc):
         data.append(frame.data[i])
-    
+
     log_message = f"ID: {frame.id:<3} DLC: {frame.dlc: <1} Data: {data}"
     rospy.loginfo(log_message)
 

--- a/ROS/example_pkg/scripts/can_logger.py
+++ b/ROS/example_pkg/scripts/can_logger.py
@@ -1,0 +1,37 @@
+""" can_logger.py
+
+Listen for and log CAN frames published by socketcan_bridge.  
+"""
+
+import rospy
+from can_msgs.msg import Frame
+
+def handle_frame(frame: Frame):
+    """ Log received CAN frame 
+    
+    frame.id = CAN Arbitration ID 
+    frame.is_rtr = Remote transmission request
+    frame.is_extended = If true, is a CANFD / extended CAN frame
+    frame.is_error = Frame is in error (CRC)
+
+    frame.dlc = Data length code (# bytes)
+    frame.data = Data (always uint8[8], only read up to DLC bytes)
+    """
+    data = []
+    for i in range(frame.dlc):
+        data.append(frame.data[i])
+    
+    log_message = f"ID: {frame.id:<3} DLC: {frame.dlc: <1} Data: {data}"
+    rospy.loginfo(log_message)
+
+def listener():
+    rospy.init_node("can_logger_node", anonymous=True, log_level=rospy.INFO)
+    rospy.loginfo("Waiting for CAN messages...")
+    rospy.Subscriber("received_messages", Frame, handle_frame)
+    rospy.spin()
+
+if __name__ == '__main__':
+    try:
+        listener()
+    except rospy.ROSInterruptException:
+        pass

--- a/ROS/example_pkg/scripts/can_sender.py
+++ b/ROS/example_pkg/scripts/can_sender.py
@@ -1,0 +1,37 @@
+""" can_sender.py
+
+Example of sending a CAN message over ROS using socketcan_bridge node. 
+Sent messages can be monitored using the can_logger node.
+"""
+
+import rospy
+from can_msgs.msg import Frame
+
+def sender():
+    pub = rospy.Publisher("sent_messages", Frame, queue_size=10)
+    rospy.init_node("can_sender", anonymous=True)
+    rospy.loginfo("Sending example CAN frame at 1 Hz...")
+
+    rate = rospy.Rate(1) # 1Hz
+    while not rospy.is_shutdown():
+        frame = Frame()
+        frame.header.stamp = rospy.Time.now()
+        
+        frame.id = 42
+        frame.is_rtr = False
+        frame.is_extended = False
+        frame.is_error = False
+        frame.dlc = 8
+        frame.data = [1, 2, 3, 4, 5, 6, 7, 8]
+        
+        log_message = f"ID: {frame.id:<3} DLC: {frame.dlc: <1} Data: {frame.data}"
+        rospy.loginfo(log_message)
+
+        pub.publish(frame)
+        rate.sleep()
+
+if __name__ == "__main__":
+    try:
+        sender()
+    except rospy.ROSInterruptException:
+        pass

--- a/ros-requirements.txt
+++ b/ros-requirements.txt
@@ -1,0 +1,1 @@
+ros-noetic-ros-canopen

--- a/rospack_setup.sh
+++ b/rospack_setup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Setup ROS workspace
 
 # Must be executed from this directory
 REPO_DIR=$(pwd) 

--- a/rospip_install.sh
+++ b/rospip_install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Install all ROS packages in the provided ros-requirements file.
+
+file=$1
+file_contents=$(cat ${file})
+
+# noglob protects against packages names with glob characters (unlikely)
+# https://unix.stackexchange.com/questions/628527/split-string-on-newline-and-write-it-into-array-using-read
+set -o noglob         
+IFS=$'\n' 
+packages=($file_contents)
+set +o noglob
+
+echo "Installing ROS packages from: ${file}"
+for i in "${packages[@]}"
+do
+   echo "Installing package: ${i}"
+   sudo apt-get install ${i}
+done


### PR DESCRIPTION
## Brief
- Added scripts for demonstrating how to send and receive messages to/from a CAN bus using ROS nodes. I added some documentation and a few nodes described below. 
- Added `paradigm.launch` file which can be used with command line tool roslaunch to launch multiple nodes at once.
- Used the `CanSender` from the tooling repo for validation. Confirmed that messages sent from the tool were received by ROS node, and also that the tool was able to read messages sent from a ROS node. This confirms that the `vcan0` virtual can bus was being interacted with properly by ROS
- Added `rospip_install.sh` and `ros-requirements.txt` as a solution for maintaining ros dependencies. Could potentially specify the nodes we need in our package.xml and then use `rosdep` to install them (I added the instructions for this in the ROS README). I wasnt sure how robust this was so I left in rospip


## Summary
`ROS/example_pkg/can_sender.py`
Simple node that publishes a CAN frame to a ROS topic, which is then forwarded to the bus by the bridge node.  
```
node->topic->bridge->can
```

`ROS/example_pkg/can_logger.py`
Simple node that reads and logs info about CAN frames that were forwarded to ROS topics by the bridge node. Tests
```
bus->bridge->topic->node
````