### PR TITLE
Initial ROS GPS Integration  

### DIFF
--- a/Examples/ROS/ros-gps.md
+++ b/Examples/ROS/ros-gps.md
@@ -1,0 +1,41 @@
+# ROS GPS Integration 
+We are using an ardusimple SimpleRTK2b evaluation board with a ublox ZED-F9P high 
+precision GNSS module. 
+
+## NMEA Over Serial 
+The GPS module is connected to the Control Laptop via USB. Using the
+u-blox u-center application, the board can be configured to output basic
+NMEA strings over serial, which can be parsed to obtain GNSS readings. 
+
+## ROS nmea-navsat-driver
+Refer: https://wiki.ros.org/nmea_navsat_driver
+
+The ROS pacakge `nmea-navsat-driver` can be used to listen over serial for NMEA strings,
+and publish GNSS readings as ROS message of type: 
+
+## Package Installation
+For ros noetifc: 
+```
+sudo apt-get install ros-noetic-nmea-navsat-driver
+```
+
+## Sample Usage
+To get up and running quickly:
+```
+rosrun nmea_navsat_driver nmea_serial_driver _port:=/dev/ttyUSB0 _baud:=38400
+```
+
+This will publish data to the following topics: 
+```
+fix: 
+    desc: GPS position fix reported by the device
+    type: sensor_msgs/NavSatFix
+    
+vel: 
+    desc: velocity output from the GPS device 
+    type: geometry_msgs/TwistStamped
+
+time_reference: timestamp from the GPS device
+    desc: GPS position fix reported by the device
+    type: sensor_msgs/TimeReference
+```

--- a/ROS/example_pkg/CMakeLists.txt
+++ b/ROS/example_pkg/CMakeLists.txt
@@ -160,6 +160,7 @@ include_directories(
 ## Mark executable scripts (Python etc.) for installation
 ## in contrast to setup.py, you can choose the destination
 catkin_install_python(PROGRAMS
+  scripts/gps_listener.py  
   scripts/talker.py
   scripts/can_logger.py
   scripts/can_sender.py

--- a/ROS/example_pkg/launch/gps_listener.launch
+++ b/ROS/example_pkg/launch/gps_listener.launch
@@ -1,0 +1,9 @@
+<launch>
+        <node pkg="nmea_navsat_driver" type="nmea_serial_driver" name="nmea_serial_driver" ns="para">
+            <param name="port" type="string" value="/dev/ttyACM0"/>
+            <param name="baud" type="int" value="38400"/>
+        </node>
+
+        <node pkg="example_pkg" type="gps_listener.py" name="gps_listener" ns="para" output="screen">
+        </node>
+</launch>

--- a/ROS/example_pkg/scripts/gps_listener.py
+++ b/ROS/example_pkg/scripts/gps_listener.py
@@ -7,7 +7,7 @@ import rospy
 from sensor_msgs.msg import NavSatFix
 
 
-gps_fix_topic = "/fix"
+gps_fix_topic = "fix"
 
 
 def handle_gps_message(fix: NavSatFix):

--- a/ROS/example_pkg/scripts/gps_listener.py
+++ b/ROS/example_pkg/scripts/gps_listener.py
@@ -1,0 +1,35 @@
+""" gps_listener.py
+
+Listen for GPS messages from the navsat driver and log them.
+"""
+
+import rospy
+from sensor_msgs.msg import NavSatFix
+
+
+gps_fix_topic = "/fix"
+
+
+def handle_gps_message(fix: NavSatFix):
+    """ Receive and log GPS fix """
+    lat = fix.latitude
+    long = fix.longitude
+    alt = fix.altitude
+    rospy.loginfo(f"Lat: {lat} Long: {long} Altitude: {alt}")
+
+
+def gps_listener_start():
+    """ Spin up ros node """
+    global gps_fix_topic
+
+    rospy.init_node("gps_listener", anonymous=True, log_level=rospy.INFO)
+    rospy.loginfo(f"Listening for GPS fix on topic: {gps_fix_topic}...")
+    rospy.Subscriber(gps_fix_topic, NavSatFix, handle_gps_message)
+    rospy.spin()
+
+
+if __name__ == "__main__":
+    try:
+        gps_listener_start()
+    except rospy.ROSInterruptException:
+        pass

--- a/ros-requirements.txt
+++ b/ros-requirements.txt
@@ -2,3 +2,4 @@ ros-noetic-ros-canopen
 ros-noetic-joy
 ros-noetic-ros-control
 ros-noetic-controllers
+ros-noetic-nmea-navsat-driver


### PR DESCRIPTION
## Brief 
Added:
- `nmea-navsat-driver` ros package requirement
- README describing its installation and usage (`Examples/ROS/ros-gps.md`)
- Example node, `ROS/example_pkg/scripts/gps_listener.py` 
- Launch file that starts the NMEA serial bridge and the gps listener (`ROS/example_pkg/launch/gps_listener.launch`)